### PR TITLE
Typo on HomePage.tsx: merged styles

### DIFF
--- a/src/app/(delete-this-and-modify-page.tsx)/HomePage.tsx
+++ b/src/app/(delete-this-and-modify-page.tsx)/HomePage.tsx
@@ -6,7 +6,7 @@ import SetupDetails from '@/app/(delete-this-and-modify-page.tsx)/SetupDetails';
 const HomePage: React.FC = () => {
     return (
         <main className='mx-auto mt-6 flex max-w-7xl flex-col justify-center gap-6 px-3 font-[family-name:var(--font-geist-sans)] sm:mt-3 sm:gap-12 sm:px-0'>
-            <div className='justify-centersm:items-start row-start-2 flex flex-col items-center gap-8'>
+            <div className='row-start-2 flex flex-col items-center justify-center gap-8 sm:items-start'>
                 <div className='flex items-center gap-4'>
                     <Image
                         className='h-6 sm:h-8 dark:invert'


### PR DESCRIPTION
`justify-center` and `sm:items-start` are currently merged into a non-working class `justify-centersm:items-start`.

prettier realigned order.